### PR TITLE
Реализовано шифрование на ЦПУ

### DIFF
--- a/app/core/encryption/AES/cpu/aescpu_backend.cpp
+++ b/app/core/encryption/AES/cpu/aescpu_backend.cpp
@@ -76,10 +76,10 @@ void AESCPUBackend::shiftRows(byte (*state)[ROWS]) {
 }
 
 void AESCPUBackend::mixColumns(byte (*state)[ROWS]) {
-    byte sum = 0;
 
     for (int col = 0; col < COLS; col++) {
         for (int row_GF = 0; row_GF < ROWS; row_GF++) {
+            byte sum = 0;
             for (int row = 0; row < ROWS; row++) {
                 sum += state[row][col] * encryption::aes::GF28[col][row];
             }

--- a/app/core/encryption/AES/cpu/aescpu_backend.cpp
+++ b/app/core/encryption/AES/cpu/aescpu_backend.cpp
@@ -6,15 +6,84 @@ byte *AESCPUBackend::encrypt(encryption::Key *key,
                              const byte *input,
                              size_t size) {
     auto result = new byte[size];
-    for (int i = 0; i < size; i++) {
-        result[i] = input[i] * 2;
+    byte state[ROWS][COLS];
+    byte *round_keys = key->expand();
+
+    for (int block_idx = 0; block_idx < size; block_idx += SECTION_SIZE) {
+
+        for (int row = 0; row < ROWS; row++) {
+            for (int col = 0; col < COLS; col++) {
+                state[row][col] = input[block_idx + row + COLS * col];
+            }
+        }
+
+        addRoundKey(state, round_keys);
+
+        for (int round_idx = 1; round_idx < ROUNDS_COUNT; round_idx++) {
+            subBytes(state);
+            shiftRows(state);
+            mixColumns(state);
+            addRoundKey(state, round_keys + round_idx * SECTION_SIZE);
+        }
+
+        subBytes(state);
+        shiftRows(state);
+        addRoundKey(state, round_keys + ROUNDS_COUNT * SECTION_SIZE);
+
+        for (int col = 0; col < COLS; col++) {
+            for (int row = 0; row < ROWS; row++) {
+                result[block_idx + row + COLS * col] = state[row][col];
+            }
+        }
     }
 
+    delete[] round_keys;
     return result;
 }
 
 void AESCPUBackend::XOR(byte *a, const byte *b, size_t size) {
     for (int i = 0; i < size; i++) {
         a[i] ^= b[i];
+    }
+}
+
+void AESCPUBackend::addRoundKey(byte (*state)[ROWS], byte *round_key) {
+    for (int row = 0; row < COLS; row++) {
+        XOR(state[row], round_key + COLS * row, ROWS);
+    }
+}
+
+void AESCPUBackend::subBytes(byte (*state)[ROWS]) {
+    for (int row = 0; row < ROWS; row++) {
+        for (int col = 0; col < COLS; col++) {
+            state[row][col] = encryption::aes::SBox[state[row][col]];
+        }
+    }
+}
+
+void AESCPUBackend::shiftRows(byte (*state)[ROWS]) {
+    byte tmp;
+
+    for (int row = 1; row < 4; row++) {
+        for (int shifts = 0; shifts < row; shifts++) {
+            tmp = state[row][0];
+            for (int col = 1; col < 4; col++) {
+                state[row][col - 1] = state[row][col];
+            }
+            state[row][COLS - 1] = tmp;
+        }
+    }
+}
+
+void AESCPUBackend::mixColumns(byte (*state)[ROWS]) {
+    byte sum = 0;
+
+    for (int col = 0; col < COLS; col++) {
+        for (int row_GF = 0; row_GF < ROWS; row_GF++) {
+            for (int row = 0; row < ROWS; row++) {
+                sum += state[row][col] * encryption::aes::GF28[col][row];
+            }
+            state[row_GF][col] = sum;
+        }
     }
 }

--- a/app/core/encryption/AES/cpu/aescpu_backend.hpp
+++ b/app/core/encryption/AES/cpu/aescpu_backend.hpp
@@ -4,7 +4,17 @@
 #include "../aes_backend.hpp"
 
 class AESCPUBackend : public encryption::aes::AESBackend {
+
+    void addRoundKey(byte state[ROWS][COLS], byte *round_key);
+
+    static void subBytes(byte state[ROWS][COLS]);
+
+    static void shiftRows(byte state[ROWS][COLS]);
+
+    static void mixColumns(byte state[ROWS][COLS]);
+
 public:
+
     AESCPUBackend();
 
     byte *encrypt(encryption::Key *key,

--- a/app/core/encryption/AES/cpu/aescpu_backend.hpp
+++ b/app/core/encryption/AES/cpu/aescpu_backend.hpp
@@ -5,7 +5,7 @@
 
 class AESCPUBackend : public encryption::aes::AESBackend {
 
-    void addRoundKey(byte state[ROWS][COLS], byte *round_key);
+    static void addRoundKey(byte state[ROWS][COLS], const byte *round_key);
 
     static void subBytes(byte state[ROWS][COLS]);
 

--- a/app/core/encryption/AES/gpu/AES.cl
+++ b/app/core/encryption/AES/gpu/AES.cl
@@ -25,14 +25,14 @@ __kernel void KeyXOR(__global unsigned char *bytes,
                      int offset,
                      unsigned int key_size) {
     int id = get_global_id(0);
-    bytes[id] ^= key[offset + id % key_size];
+    bytes[id] ^= key[offset * key_size + id % key_size];
 }
 
 __kernel void subBytes(__global unsigned char *bytes,
                        __global unsigned char *SBox,
                        __global unsigned char *InvSBox) {
     int id = get_global_id(0);
-    bytes[id] = InvSBox[SBox[bytes[id]]];
+    bytes[id] = SBox[bytes[id]];
 }
 
 __kernel void shiftRows(__global unsigned char *row, int len) {
@@ -49,12 +49,12 @@ __kernel void shiftRows(__global unsigned char *row, int len) {
 }
 
 __kernel void mixColumns(__global unsigned char *bytes, __global unsigned char *GF28, int len) {
-    unsigned char sum = 0;
-    int id = get_global_id(0);
-    int i;
-    for (i = 0; i < len; i++) {
-        sum += bytes[id * len + i] * GF28[id * 4 + i];
+    int col = get_global_id(0);
+    for (int row = 0; row < 4; row++) {
+        unsigned char sum = 0;
+        for (int i = 0; i < 4; i++) {
+            sum += bytes[col + i * 4] * GF28[(col % 4) * 4 + i];
+        }
+        bytes[row * 4 + col] = sum;
     }
-
-    bytes[id * len + i] = sum;
 }

--- a/app/core/encryption/AES/gpu/aesgpu_backend.cpp
+++ b/app/core/encryption/AES/gpu/aesgpu_backend.cpp
@@ -71,6 +71,11 @@ byte *AESGPUBackend::encrypt(encryption::Key *key,
                                      SECTION_SIZE * (ROUNDS_COUNT + 1),
                                      round_keys);
 
+/*    command_queue.finish();
+    auto xxx = new byte[size];
+    command_queue.enqueueReadBuffer(states, CL_TRUE, 0, size, xxx);*/
+
+
     KeyXOR(states, RoundKeys, 0, size);
 
     for (int round_idx = 1; round_idx < ROUNDS_COUNT; round_idx++) {
@@ -126,7 +131,7 @@ void AESGPUBackend::load_states(const byte *input, size_t size) {
     size_t blocks_count = size / SECTION_SIZE;
     command_queue.enqueueNDRangeKernel(kernel[KF_LOAD_STATES],
                                        cl::NullRange,
-                                       cl::NDRange(blocks_count * 4, 4));
+                                       cl::NDRange(size));
 }
 
 byte *AESGPUBackend::unload_states(size_t size) {
@@ -136,7 +141,7 @@ byte *AESGPUBackend::unload_states(size_t size) {
     size_t blocks_count = size / SECTION_SIZE;
     command_queue.enqueueNDRangeKernel(kernel[KF_UNLOAD_STATES],
                                        cl::NullRange,
-                                       cl::NDRange(blocks_count * 4, 4));
+                                       cl::NDRange(size));
     command_queue.finish();
     auto result = new byte[size];
     command_queue.enqueueReadBuffer(result_buf, CL_TRUE, 0, size, result);
@@ -165,5 +170,5 @@ void AESGPUBackend::mix_columns(const cl::Buffer &bytes, size_t size) {
     kernel[KF_MIX_COLUMNS].setArg(2, COLS);
     command_queue.enqueueNDRangeKernel(kernel[KF_MIX_COLUMNS],
                                        cl::NullRange,
-                                       cl::NDRange(size / ROWS));
+                                       cl::NDRange(size / 16));
 }

--- a/app/core/encryption/AES/gpu/aesgpu_backend.cpp
+++ b/app/core/encryption/AES/gpu/aesgpu_backend.cpp
@@ -35,7 +35,7 @@ AESGPUBackend::AESGPUBackend() {
     std::cout << "Using GPU device " << device.getInfo<CL_DEVICE_NAME>() << "\n";
     SBox = cl::Buffer(context, CL_MEM_READ_ONLY, sizeof(encryption::aes::SBox));
     InvSBox = cl::Buffer(context, CL_MEM_READ_ONLY, sizeof(encryption::aes::InvSBox));
-    RoundKeys = cl::Buffer(context, CL_MEM_READ_WRITE, SECTION_SIZE * ROUNDS_COUNT);
+    RoundKeys = cl::Buffer(context, CL_MEM_READ_WRITE, SECTION_SIZE * (ROUNDS_COUNT + 1));
     GF28 = cl::Buffer(context, CL_MEM_READ_ONLY, sizeof(encryption::aes::GF28));
     command_queue.enqueueWriteBuffer(SBox,
                                      CL_TRUE,


### PR DESCRIPTION
ченджлог фиксов совместимости:
- фикс loadStates и unloadStates в AES.cl
- фикс KeyXOR в AES.cl таким образом, что теперь столбцы а не строки states ксорятся со словом ключа (как это и должно быть) и соответственно такой же фикс addRoundKey на цпу
- фикс mixColumns в AES.cl таким образом, что теперь столбцы states правильно умножаются на матрицу GF28 и соответствующий фикс на цпу